### PR TITLE
Error 500 on PHP 8.1 (MAMP Pro)

### DIFF
--- a/core/components/langrouter/src/Plugins/Events/OnHandleRequest.php
+++ b/core/components/langrouter/src/Plugins/Events/OnHandleRequest.php
@@ -83,8 +83,8 @@ class OnHandleRequest extends Plugin
 
                 // Set locale since $this->modx->_initCulture is called before OnHandleRequest
                 if ($this->modx->context && $this->modx->getOption('setlocale', null, true)) {
-                    $locale = setlocale(LC_ALL, null);
-                    setlocale(LC_ALL, $this->modx->context->getOption('locale', null, $locale));
+                    $locale = setlocale(LC_ALL, 0);
+                    setlocale(LC_ALL, $this->modx->context->getOption('locale', 0, $locale));
                 }
             }
         }

--- a/core/components/langrouter/src/Plugins/Events/OnHandleRequest.php
+++ b/core/components/langrouter/src/Plugins/Events/OnHandleRequest.php
@@ -84,7 +84,7 @@ class OnHandleRequest extends Plugin
                 // Set locale since $this->modx->_initCulture is called before OnHandleRequest
                 if ($this->modx->context && $this->modx->getOption('setlocale', null, true)) {
                     $locale = setlocale(LC_ALL, 0);
-                    setlocale(LC_ALL, $this->modx->context->getOption('locale', 0, $locale));
+                    setlocale(LC_ALL, $this->modx->context->getOption('locale', null, $locale));
                 }
             }
         }


### PR DESCRIPTION
Calling `setlocale(LC_ALL, null)` in OnHandleRequest.php produces error 500 on PHP 8.1 (MAMP Pro)

Changing it to `setlocale(LC_ALL, 0)` fixes the error and LangRouter works perfectly.